### PR TITLE
Locking API version for Amazon DynamoDB

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,7 +20,7 @@ vogels.dynamoDriver = internals.dynamoDriver = function (driver) {
     internals.dynamodb = driver;
     internals.updateDynamoDBDriverForAllModels(driver);
   } else {
-    internals.dynamodb = internals.dynamodb || new vogels.AWS.DynamoDB();
+    internals.dynamodb = internals.dynamodb || new vogels.AWS.DynamoDB({apiVersion: '2012-08-10'});
   }
 
   return internals.dynamodb;


### PR DESCRIPTION
The aws-sdk package supports locking a service interface to a specific
API version.  This isolates the client from future changes in the
service API that are backwards incompatible.
