### PR TITLE
Implementing toJSON function on Item

### DIFF
--- a/lib/item.js
+++ b/lib/item.js
@@ -82,3 +82,7 @@ Item.prototype.destroy = function (options, callback) {
 
   self.table.destroy(this.attrs, options, callback);
 };
+
+Item.prototype.toJSON = function() {
+  return this.attrs;
+};

--- a/test/item-test.js
+++ b/test/item-test.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var Item = require('../lib/item'),
+		Table = require('../lib/table'),
+		Schema = require('../lib/schema'),
+    chai = require('chai'),
+    expect = chai.expect,
+    helper = require('./test-helper');
+
+chai.should();
+
+describe('item', function() {
+	it('JSON.stringify should only serialize attrs', function() {    
+		var schema = new Schema();
+		schema.Number('num');
+		schema.String('name');
+
+    var table = new Table('mockTable', schema, helper.mockSerializer(), helper.mockDynamoDB());
+    var attrs = {num: 1, name: 'foo'};
+    var item = new Item(attrs, table);
+    var stringified = JSON.stringify(item);
+
+    stringified.should.equal(JSON.stringify(attrs));
+  });	
+});


### PR DESCRIPTION
Invoking JSON.stringify on an Item instance can cause execution to hang, probably due to circular references within the Table object that is part of the internal Item state. It seems reasonable to assume that serializing only the attributes is desired when invoking JSON.stringify on a vogels Item instance. One example of this is a REST service implemented with Express where the Response.json function internally invokes JSON.stringify. 

According to Crockford's json2 standard, a toJSON function can be implemented on an object which returns the actual object that should be serialized. In this case simply returning "this.attrs" does the trick.

http://stackoverflow.com/questions/4289282/how-do-you-use-json-stringify-in-a-custom-tojson-method
