### PR TITLE
Allow for dynamic table names.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -74,6 +74,7 @@ internals.compileModel = function (name, schema) {
   });
 
   Model.config = function(config) {
+    var tableConfig,
     config = config || {};
 
     if(config.tableName) {
@@ -84,7 +85,14 @@ internals.compileModel = function (name, schema) {
       table.dynamodb = config.dynamodb;
     }
 
-    return table.config;
+    tableConfig = table.config;
+
+    // If the table name is dynamic, execute the function.
+    if (_.isFunction(table.config.name)) {
+      tableConfig.name = table.config.name();
+    }
+
+    return tableConfig;
   };
 
   return vogels.model(name, Model);
@@ -109,6 +117,9 @@ vogels.define = function (modelName, callback) {
     callback(schema);
   }
 
+  if (schema.tableName) {
+    compiledTable.config().name = schema.tableName;
+  }
   return compiledTable;
 };
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -11,7 +11,7 @@ var _            = require('lodash'),
 var internals = {};
 
 var Table = module.exports = function (name, schema, serializer, dynamodb) {
-  this.config = {name : name};
+  this.config = {};
   this.schema = schema;
   this.serializer = serializer;
   this.dynamodb = dynamodb;
@@ -21,6 +21,14 @@ var Table = module.exports = function (name, schema, serializer, dynamodb) {
 
   this._after= new EventEmitter();
   this.after = this._after.on.bind(this._after);
+
+  // If the schema has defined a table name function, set that as the name, otherwise
+  // set the passed in name.
+  if (schema && _.isFunction(schema.tableName)) {
+    this.config.name = schema.tableName;
+  } else {
+    this.config.name = name;
+  }
 };
 
 Table.prototype.initItem = function (attrs) {
@@ -54,7 +62,7 @@ Table.prototype.get = function (hashKey, rangeKey, options, callback) {
   }
 
   var params = {
-    TableName : self.config.name.toString(),
+    TableName : _.isFunction(self.config.name) ? self.config.name() : self.config.name,
     Key : self.serializer.buildKey(hashKey, rangeKey, self.schema)
   };
 
@@ -107,7 +115,7 @@ Table.prototype.create = function (item, options, callback) {
     }
 
     var params = {
-      TableName : self.config.name.toString(),
+      TableName : _.isFunction(self.config.name) ? self.config.name() : self.config.name,
       Item : self.serializer.serializeItem(self.schema, data)
     };
 
@@ -151,7 +159,7 @@ Table.prototype.update = function (item, options, callback) {
     var rangeKey = data[self.schema.rangeKey] || null;
 
     var params = {
-      TableName : self.config.name.toString(),
+      TableName : _.isFunction(self.config.name) ? self.config.name() : self.config.name,
       Key : self.serializer.buildKey(hashKey, rangeKey, self.schema),
       AttributeUpdates : self.serializer.serializeItemForUpdate(self.schema, 'PUT', data),
       ReturnValues : 'ALL_NEW'
@@ -210,7 +218,7 @@ Table.prototype.destroy = function (hashKey, rangeKey, options, callback) {
   }
 
   var params = {
-    TableName : self.config.name.toString(),
+    TableName : _.isFunction(self.config.name) ? self.config.name() : self.config.name,
     Key : self.serializer.buildKey(hashKey, rangeKey, self.schema)
   };
 
@@ -390,7 +398,7 @@ Table.prototype.createTable = function (options, callback) {
 
   var params = {
     AttributeDefinitions : attributeDefinitions,
-    TableName : self.config.name.toString(),
+    TableName : _.isFunction(self.config.name) ? self.config.name() : self.config.name,
     KeySchema : keySchema,
     ProvisionedThroughput : {
       ReadCapacityUnits : options.readCapacity || 1,
@@ -412,7 +420,7 @@ Table.prototype.createTable = function (options, callback) {
 Table.prototype.describeTable = function (callback) {
 
   var params = {
-    TableName : this.config.name.toString()
+    TableName : _.isFunction(this.config.name) ? this.config.name() : this.config.name
   };
 
   this.dynamodb.describeTable(params, callback);
@@ -422,7 +430,7 @@ Table.prototype.updateTable = function (throughput, callback) {
   callback = callback || function () {};
 
   var params = {
-    TableName : this.config.name.toString(),
+    TableName : _.isFunction(this.config.name) ? this.config.name() : this.config.name,
     ProvisionedThroughput : {
       ReadCapacityUnits : throughput.readCapacity,
       WriteCapacityUnits : throughput.writeCapacity

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -45,6 +45,20 @@ describe('vogels', function () {
       acc.table.should.be.instanceof(Table);
     });
 
+    it('should set table name', function() {
+      var d = new Date(),
+          Account = vogels.define('Account', function (schema) {
+        schema.String('email', {hashKey: true});
+        schema.String('name');
+        schema.Number('age');
+        schema.Date('created', {default: Date.now});
+
+        schema.tableName = function () {
+          return ['Accounts', d.getFullYear(), d.getMonth(), d.getDate()].join('_');
+        };
+      });
+      Account.config().name.should.equal(['Accounts', d.getFullYear(), d.getMonth(), d.getDate()].join('_'));
+    });
   });
 
   describe('#models', function () {

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -778,26 +778,21 @@ describe('table', function () {
     });
 
     it('should work with a dynamic table name', function (done) {
+      var d = new Date(),
+          tableName = ['Accounts', d.getFullYear(), d.getMonth(), d.getDate()].join('_');
       schema.String('email', {hashKey: true});
       schema.String('name');
-
-      function dynamicTable() { }
-      dynamicTable.prototype.toString = function() {
-        return 'accounts';
-      }
-       
-      var tableName = new dynamicTable();
-      table = new Table('accounts', schema, serializer, dynamodb);
-
-      var request = {
-        TableName: tableName
+      schema.tableName = function () {
+        return tableName;
       };
+
+      table = new Table('accounts', schema, serializer, dynamodb);
 
       dynamodb.describeTable.yields(null, {});
 
       table.describeTable(function (err) {
         expect(err).to.be.null;
-        dynamodb.describeTable.calledWith({TableName: 'accounts'}).should.be.true;
+        dynamodb.describeTable.calledWith({TableName: tableName}).should.be.true;
         done();
       });
 


### PR DESCRIPTION
This adds a toString() call to the TableName parameter when sending a request to Dynamo. This will allow the table name to be either a string, or anything that will output a table name as its toString output. For example, we are using a table class that allows us to generate prefixes based off of the environment settings (_test_table), and also suffixes for our time-series tables (table_0314).

This may not be the right way to go about this, but it was the simplest and didn't break anything that I could see.
