### PR TITLE
delete missing properties instead of setting them to null

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -342,6 +342,9 @@ serializer.deserializeItem = function (schema, item) {
 
   var deserialized = _.reduce(schema.attrs, function (result, attr, key) {
     result[key] = internals.deserializeAttribute(item[key], attr);
+      if (result[key] == null) {
+          delete(result[key]);
+      }
 
     return result;
   }, {});


### PR DESCRIPTION
for #27 if it makes sense.

Added benefit of also removing null values from `toJSON()` as discussed in #13
