### PR TITLE
omit empty strings when serializing

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -8,7 +8,7 @@ var utils = module.exports;
 
 utils.omitNulls = function (data) {
   return _.omit(data, function(value) {
-    return _.isNull(value) || _.isUndefined(value) || (_.isArray(value) && _.isEmpty(value));
+    return _.isNull(value) || _.isUndefined(value) || (_.isArray(value) && _.isEmpty(value)) || value === '';
   });
 };
 


### PR DESCRIPTION
if `allow('')` is set we should strip any attributes that contain an empty string since DynamoDB does not allow empty strings to be saved.