### PR TITLE
Allow secondary index options

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,7 +506,21 @@ BlogPost
   .exec(callback);
 ```
 
-Learn more about [secondary indexes][3]
+You can also specify secondary index options by passing an object literal instead of `true` for the value of `secondaryIndex`:
+
+```js
+var Author = vogels.define('Author', function (schema) {
+  schema.String('email', {hashKey: true});
+  schema.String('name');
+  schema.Date('updated', {secondaryIndex: {
+    Projection: {
+      ProjectionType: 'KEYS_ONLY'
+    }
+  }});
+});
+```
+
+Learn more about [secondary indexes][3].
 
 ### Scan
 Vogels provides a flexible and chainable api for scanning over all your items

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -15,7 +15,11 @@ internals.parseOptions = function (schema, name, options) {
   } else if(options.rangeKey) {
     schema.rangeKey = name;
   } else if(options.secondaryIndex) {
-    schema.secondaryIndexes.push(name);
+    if (_.isPlainObject(options.secondaryIndex)) {
+      schema.secondaryIndexes[name] = options.secondaryIndex;
+    } else {
+      schema.secondaryIndexes[name] = name;
+    }
   }
 };
 
@@ -45,7 +49,7 @@ internals.baseSetup = function (schema, attrName, type, attributeType, options) 
 
 var Schema = module.exports = function () {
   this.attrs = {};
-  this.secondaryIndexes = [];
+  this.secondaryIndexes = {};
   this.globalIndexes = {};
 };
 

--- a/lib/table.js
+++ b/lib/table.js
@@ -338,16 +338,21 @@ internals.keySchema = function (hashKey, rangeKey) {
   return result;
 };
 
-internals.secondaryIndex = function (schema, indexKey) {
-  var indexName = indexKey + 'Index';
+internals.secondaryIndex = function (schema, indexKey, indexOpts) {
+  var indexName = indexKey + 'Index',
+      defaults = {
+        IndexName : indexName,
+        KeySchema : internals.keySchema(schema.hashKey, indexKey),
+        Projection : {
+          ProjectionType : 'ALL'
+        }
+      };
 
-  return {
-    IndexName : indexName,
-    KeySchema : internals.keySchema(schema.hashKey, indexKey),
-    Projection : {
-      ProjectionType : 'ALL'
-    }
-  };
+  if(_.isPlainObject(indexOpts)) {
+    return _.defaults(indexOpts, defaults);
+  } else {
+    return defaults;
+  }
 };
 
 internals.globalIndex = function (indexName, params) {
@@ -381,9 +386,9 @@ Table.prototype.createTable = function (options, callback) {
 
   var localSecondaryIndexes = [];
 
-  _.forEach(self.schema.secondaryIndexes, function (key) {
+  _.forEach(self.schema.secondaryIndexes, function (indexOpts, key) {
     attributeDefinitions.push(internals.attributeDefinition(self.schema, key));
-    localSecondaryIndexes.push(internals.secondaryIndex(self.schema, key));
+    localSecondaryIndexes.push(internals.secondaryIndex(self.schema, key, indexOpts));
   });
 
   var globalSecondaryIndexes = [];

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -38,7 +38,18 @@ describe('schema', function () {
     it('should set secondaryIndexes', function () {
       schema.String('name', {secondaryIndex: true});
 
-      schema.secondaryIndexes.should.eql(['name']);
+      schema.secondaryIndexes.should.eql({name: 'name'});
+    });
+
+    it('should set secondaryIndex options if an object is provided for the secondaryIndex key', function () {
+      var secondaryIndexOptions = {
+        Projection : {
+          ProjectionType: 'KEYS_ONLY'
+        }
+      };
+      schema.String('name', {secondaryIndex: secondaryIndexOptions});
+
+      schema.secondaryIndexes.should.eql({name: secondaryIndexOptions});
     });
 
   });


### PR DESCRIPTION
When defining a new model, this PR allows you to specify an object literal for `options.secondaryIndex` instead of `true`, in order to be able to override the default secondary index options. Let me know if you have any questions!