### PR TITLE
Support Map, List and Bool type

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,10 @@ Map can recursively define its schema:
 ```js
 var Photo = vogels.define('Photo', function (schema) {
   schema.String('userid', {hashKey: true});
-  schema.Map('tags', function(schema) {
+  schema.Map('location', function(schema) {
     schema.String('name');
-    schema.String('url');
+    schema.String('latitude');
+    schema.String('longitude');
   });
 });
 ```

--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Vogels provides the following schema types:
 * Date
 * UUID
 * TimeUUID
+* Map
+* List
 
 #### UUID
 UUIDs can be declared for any attributes, including hash and range keys. By
@@ -77,6 +79,33 @@ var Tweet = vogels.define('Account', function (schema) {
   schema.Date('created', {default: Date.now});
 });
 ```
+
+#### Map
+Map can be declared for any attributes, except for hash and range keys.
+It can store an object in the attribute.
+
+```js
+var Photo = vogels.define('Photo', function (schema) {
+  schema.String('userid', {hashKey: true});
+  schema.Map('tags');
+});
+
+Photo.create({userid:'john', tags: {emily: {x:10, y:8}}}, console.log);
+```
+
+#### List
+Map can be declared for any attributes, except for hash and range keys.
+It can store an array in the attribute.
+
+```js
+var Photo = vogels.define('Photo', function (schema) {
+  schema.String('userid', {hashKey: true});
+  schema.List('likes');
+});
+
+Photo.create({userid:'john', likes: ['emily']}, console.log);
+```
+
 
 ### Configuration
 After you've defined your model you can configure the table name to use.

--- a/README.md
+++ b/README.md
@@ -93,8 +93,20 @@ var Photo = vogels.define('Photo', function (schema) {
 Photo.create({userid:'john', tags: {emily: {x:10, y:8}}}, console.log);
 ```
 
+Map can recursively define its schema:
+
+```js
+var Photo = vogels.define('Photo', function (schema) {
+  schema.String('userid', {hashKey: true});
+  schema.Map('tags', function(schema) {
+    schema.String('name');
+    schema.String('url');
+  });
+});
+```
+
 #### List
-Map can be declared for any attributes, except for hash and range keys.
+List can be declared for any attributes, except for hash and range keys.
 It can store an array in the attribute.
 
 ```js
@@ -106,6 +118,17 @@ var Photo = vogels.define('Photo', function (schema) {
 Photo.create({userid:'john', likes: ['emily']}, console.log);
 ```
 
+List can define schema of its element:
+
+```js
+var Photo = vogels.define('Photo', function (schema) {
+  schema.String('userid', {hashKey: true});
+  schema.List('likes', function(schema) {
+    schema.String('userid');
+    schema.Date('likedAt');
+  });
+});
+```
 
 ### Configuration
 After you've defined your model you can configure the table name to use.

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -91,18 +91,20 @@ Schema.types.TimeUUID = function () {
   return uuidType;
 };
 
-Schema.types.Map = function () {
+Schema.types.Map = function (schema) {
   var mapType = Joi.object();
 
   mapType._type = 'map';
+  mapType._schema = schema;
 
   return mapType;
 };
 
-Schema.types.List = function () {
+Schema.types.List = function (schema) {
   var listType = Joi.array();
 
   listType._type = 'list';
+  listType._schema = schema;
 
   return listType;
 };
@@ -162,14 +164,38 @@ Schema.prototype.TimeUUID = function (attrName, options) {
   return internals.baseSetup(this, attrName, Schema.types.TimeUUID(), attributeType,  opts);
 };
 
-Schema.prototype.Map = function (attrName, options) {
+Schema.prototype.Map = function (attrName, options, callback) {
   var attributeType = 'M';
-  return internals.baseSetup(this, attrName, Schema.types.Map(), attributeType, options);
+
+  if(typeof options=='function') {
+    callback = options;
+    options = undefined;
+  }
+
+  var subSchema = undefined;
+  if(_.isFunction(callback)) {
+    subSchema = new Schema();
+    callback(subSchema);
+  }
+
+  return internals.baseSetup(this, attrName, Schema.types.Map(subSchema), attributeType, options);
 };
 
-Schema.prototype.List = function (attrName, options) {
+Schema.prototype.List = function (attrName, options, callback) {
   var attributeType = 'L';
-  return internals.baseSetup(this, attrName, Schema.types.List(), attributeType, options);
+
+  if(_.isFunction(options)) {
+    callback = options;
+    options = undefined;
+  }
+
+  var subSchema = undefined;
+  if(_.isFunction(callback)) {
+    subSchema = new Schema();
+    callback(subSchema);
+  }
+
+  return internals.baseSetup(this, attrName, Schema.types.List(subSchema), attributeType, options);
 };
 
 Schema.prototype.validate = function (params) {

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -91,6 +91,23 @@ Schema.types.TimeUUID = function () {
   return uuidType;
 };
 
+Schema.types.Map = function () {
+  var mapType = Joi.object();
+
+  mapType._type = 'map';
+
+  return mapType;
+};
+
+Schema.types.List = function () {
+  var listType = Joi.array();
+
+  listType._type = 'list';
+
+  return listType;
+};
+
+
 Schema.prototype.String = function (attrName, options) {
   var attributeType = 'S';
   return internals.baseSetup(this, attrName, Joi.string(), attributeType, options);
@@ -107,7 +124,7 @@ Schema.prototype.Binary = function (attrName, options) {
 };
 
 Schema.prototype.Boolean = function (attrName, options) {
-  var attributeType = 'N';
+  var attributeType = 'BOOL';
   return internals.baseSetup(this, attrName, Joi.boolean(), attributeType, options);
 };
 
@@ -143,6 +160,16 @@ Schema.prototype.TimeUUID = function (attrName, options) {
 
   var attributeType = 'S';
   return internals.baseSetup(this, attrName, Schema.types.TimeUUID(), attributeType,  opts);
+};
+
+Schema.prototype.Map = function (attrName, options) {
+  var attributeType = 'M';
+  return internals.baseSetup(this, attrName, Schema.types.Map(), attributeType, options);
+};
+
+Schema.prototype.List = function (attrName, options) {
+  var attributeType = 'L';
+  return internals.baseSetup(this, attrName, Schema.types.List(), attributeType, options);
 };
 
 Schema.prototype.validate = function (params) {

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -70,7 +70,7 @@ var serialize = internals.serialize = {
   map : function (value) {
     if(_.isObject(value)) {
 
-      var serialized = _.each(value, function(val, key, map) {
+      var serialized = _.each(_.extend({}, value), function(val, key, map) {
 
         var sval = undefined;
         if (_.isString(val)) {

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -28,10 +28,10 @@ var serialize = internals.serialize = {
   },
 
   boolean : function (value) {
-    if (value && value !== 'false') {
-      return {N: '1'};
+    if(_.isBoolean(value)) {
+      return {BOOL: value};
     } else {
-      return {N: '0'};
+      return {BOOL: !!value};
     }
   },
 
@@ -57,6 +57,71 @@ var serialize = internals.serialize = {
     } else {
       return {BS: [new Buffer(value).toString('base64')]};
     }
+  },
+
+  map : function (value) {
+    if(_.isObject(value)) {
+
+      var serialized = _.each(value, function(val, key, map) {
+
+        var sval = undefined;
+        if (_.isString(val)) {
+          sval = serialize.string(val);
+        } else if (_.isNumber(val)) {
+          sval = serialize.number(val);
+        } else if (val instanceof Buffer) {
+          sval = serialize.binary(val);
+        } else if (_.isDate(val)) {
+          sval = serialize.date(val);
+        } else if (_.isBoolean(val)) {
+          sval = serialize.boolean(val);
+        } else if (_.isObject(val)) {
+          sval = serialize.map(val);
+        } else if (_.isArray(val)) {
+          sval = serialize.list(val);
+        }
+        if (sval !== undefined) {
+          map[key] = sval;
+        }
+      });
+
+      return {M: serialized};
+
+    } else {
+      return null;
+    }
+  },
+
+  list : function (value) {
+    if(_.isArray(value)) {
+
+      var serialized = _.map(value, function(val) {
+
+        if (_.isString(val)) {
+          return serialize.string(val);
+        } else if (_.isNumber(val)) {
+          return serialize.number(val);
+        } else if (val instanceof Buffer) {
+          return serialize.binary(val);
+        } else if (_.isDate(val)) {
+          return serialize.date(val);
+        } else if (_.isBoolean(val)) {
+          return serialize.boolean(val);
+        } else if (_.isObject(val)) {
+          return serialize.map(val);
+        } else if (_.isArray(val)) {
+          return serialize.list(val);
+        } else {
+          return val;
+        }
+
+      });
+
+      return {L: serialized};
+
+    } else {
+      return null;
+    }
   }
 
 };
@@ -81,6 +146,8 @@ var deserializer = internals.deserializer = {
       return value.S === 'true';
     } else if (value.B) {
       return new Buffer(value.B, 'base64').toString() === 'true';
+    } else if (value.BOOL) {
+      return value.BOOL;
     } else {
       return false;
     }
@@ -168,6 +235,50 @@ var deserializer = internals.deserializer = {
     } else {
       return [];
     }
+  },
+
+  map : function (value) {
+    if(value.M) {
+      return _.each(value.M, function(val, key, map){
+        if (val.S) {
+          map[key] = deserializer.string(val);
+        } else if (val.N) {
+          map[key] = deserializer.number(val);
+        } else if (val.BOOL) {
+          map[key] = deserializer.boolean(val);
+        } else if (val.M) {
+          map[key] = deserializer.map(val);
+        } else if (val.L) {
+          map[key] = deserializer.list(val);
+        } else {
+          delete map[key];
+        }
+      });
+    } else {
+      return {};
+    }
+  },
+
+  list : function (value) {
+    if(value.L) {
+      return _.map(value.L, function(val){
+        if (val.S) {
+          return deserializer.string(val);
+        } else if (val.N) {
+          return deserializer.number(val);
+        } else if (val.BOOL) {
+          return deserializer.boolean(val);
+        } else if (val.M) {
+          return deserializer.map(val);
+        } else if (val.L) {
+          return deserializer.list(val);
+        } else {
+          return undefined;
+        }
+      });
+    } else {
+      return [];
+    }
   }
 };
 
@@ -197,6 +308,10 @@ internals.deserializeAttribute = function (value, attr) {
     return deserializer.stringSet(value);
   case 'binarySet':
     return deserializer.binarySet(value);
+  case 'map':
+    return deserializer.map(value);
+  case 'list':
+    return deserializer.list(value);
   default:
     throw new Error('Unsupported schema type - ' + type);
   }
@@ -239,6 +354,10 @@ internals.serializeAttribute = function (value, attr, options) {
       return serialize.binary(value);
     }
     return serialize.binarySet(value);
+  case 'map':
+    return serialize.map(value);
+  case 'list':
+    return serialize.list(value);
   default:
     throw new Error('Unsupported schema type - ' + type);
   }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -67,60 +67,72 @@ var serialize = internals.serialize = {
     }
   },
 
-  map : function (value) {
+  map : function (value, schema) {
     if(_.isObject(value)) {
 
-      var serialized = _.each(_.extend({}, value), function(val, key, map) {
+      if(schema) {
+        var serialized = serializer.serializeItem(schema, value, {});
+        return {M: serialized};
+      }
+      else {
+        var serialized = _.each(_.extend({}, value), function(val, key, map) {
 
-        var sval = undefined;
-        if (_.isString(val)) {
-          sval = serialize.string(val);
-        } else if (_.isNumber(val)) {
-          sval = serialize.number(val);
-        } else if (val instanceof Buffer) {
-          sval = serialize.binary(val);
-        } else if (_.isDate(val)) {
-          sval = serialize.date(val);
-        } else if (_.isBoolean(val)) {
-          sval = serialize.boolean(val);
-        } else if (_.isObject(val)) {
-          sval = serialize.map(val);
-        } else if (_.isArray(val)) {
-          sval = serialize.list(val);
-        }
-        if (sval !== undefined) {
-          map[key] = sval;
-        }
-      });
+          var sval = undefined;
+          if (_.isString(val)) {
+            sval = serialize.string(val);
+          } else if (_.isNumber(val)) {
+            sval = serialize.number(val);
+          } else if (val instanceof Buffer) {
+            sval = serialize.binary(val);
+          } else if (_.isDate(val)) {
+            sval = serialize.date(val);
+          } else if (_.isBoolean(val)) {
+            sval = serialize.boolean(val);
+          } else if (_.isObject(val)) {
+            sval = serialize.map(val);
+          } else if (_.isArray(val)) {
+            sval = serialize.list(val);
+          }
+          if (sval !== undefined) {
+            map[key] = sval;
+          }
+        });
 
-      return {M: serialized};
+        return {M: serialized};
+      }
 
     } else {
       return null;
     }
   },
 
-  list : function (value) {
+  list : function (value, schema) {
     if(_.isArray(value)) {
 
       var serialized = _.map(value, function(val) {
 
-        if (_.isString(val)) {
-          return serialize.string(val);
-        } else if (_.isNumber(val)) {
-          return serialize.number(val);
-        } else if (val instanceof Buffer) {
-          return serialize.binary(val);
-        } else if (_.isDate(val)) {
-          return serialize.date(val);
-        } else if (_.isBoolean(val)) {
-          return serialize.boolean(val);
-        } else if (_.isObject(val)) {
-          return serialize.map(val);
-        } else if (_.isArray(val)) {
-          return serialize.list(val);
-        } else {
-          return val;
+        if(schema) {
+          var d = serializer.serializeItem(schema, val, {});
+          return {M: d};
+        }
+        else {
+          if (_.isString(val)) {
+            return serialize.string(val);
+          } else if (_.isNumber(val)) {
+            return serialize.number(val);
+          } else if (val instanceof Buffer) {
+            return serialize.binary(val);
+          } else if (_.isDate(val)) {
+            return serialize.date(val);
+          } else if (_.isBoolean(val)) {
+            return serialize.boolean(val);
+          } else if (_.isObject(val)) {
+            return serialize.map(val);
+          } else if (_.isArray(val)) {
+            return serialize.list(val);
+          } else {
+            return val;
+          }
         }
 
       });
@@ -245,45 +257,62 @@ var deserializer = internals.deserializer = {
     }
   },
 
-  map : function (value) {
+  map : function (value, schema) {
     if(value.M) {
-      return _.each(value.M, function(val, key, map){
-        if (val.S) {
-          map[key] = deserializer.string(val);
-        } else if (val.N) {
-          map[key] = deserializer.number(val);
-        } else if (val.BOOL) {
-          map[key] = deserializer.boolean(val);
-        } else if (val.M) {
-          map[key] = deserializer.map(val);
-        } else if (val.L) {
-          map[key] = deserializer.list(val);
-        } else {
-          delete map[key];
-        }
-      });
+      if(schema) {
+        return serializer.deserializeItem(schema, value.M);
+      }
+      else {
+        return _.each(value.M, function(val, key, map){
+          if (val.S) {
+            map[key] = deserializer.string(val);
+          } else if (val.N) {
+            map[key] = deserializer.number(val);
+          } else if (val.BOOL) {
+            map[key] = deserializer.boolean(val);
+          } else if (val.M) {
+            map[key] = deserializer.map(val);
+          } else if (val.L) {
+            map[key] = deserializer.list(val);
+          } else {
+            delete map[key];
+          }
+        });
+      }
     } else {
       return {};
     }
   },
 
-  list : function (value) {
+  list : function (value, schema) {
     if(value.L) {
-      return _.map(value.L, function(val){
-        if (val.S) {
-          return deserializer.string(val);
-        } else if (val.N) {
-          return deserializer.number(val);
-        } else if (val.BOOL) {
-          return deserializer.boolean(val);
-        } else if (val.M) {
-          return deserializer.map(val);
-        } else if (val.L) {
-          return deserializer.list(val);
-        } else {
-          return undefined;
-        }
-      });
+      if(schema) {
+        return _.map(value.L, function(val){
+          if(val.M) {
+            return serializer.deserializeItem(schema, val.M);
+          }
+          else {
+            return undefined;
+          }
+        });
+      }
+      else {
+        return _.map(value.L, function(val){
+          if (val.S) {
+            return deserializer.string(val);
+          } else if (val.N) {
+            return deserializer.number(val);
+          } else if (val.BOOL) {
+            return deserializer.boolean(val);
+          } else if (val.M) {
+            return deserializer.map(val);
+          } else if (val.L) {
+            return deserializer.list(val);
+          } else {
+            return undefined;
+          }
+        });
+      }
     } else {
       return [];
     }
@@ -296,6 +325,7 @@ internals.deserializeAttribute = function (value, attr) {
   }
 
   var type = attr.type._type;
+  var subSchema = attr.type._schema;
 
   switch(type){
   case 'string':
@@ -317,9 +347,9 @@ internals.deserializeAttribute = function (value, attr) {
   case 'binarySet':
     return deserializer.binarySet(value);
   case 'map':
-    return deserializer.map(value);
+    return deserializer.map(value, subSchema);
   case 'list':
-    return deserializer.list(value);
+    return deserializer.list(value, subSchema);
   default:
     throw new Error('Unsupported schema type - ' + type);
   }
@@ -333,6 +363,7 @@ internals.serializeAttribute = function (value, attr, options) {
   options = options || {};
 
   var type = attr.type._type;
+  var subSchema = attr.type._schema;
 
   switch(type){
   case 'string':
@@ -363,9 +394,9 @@ internals.serializeAttribute = function (value, attr, options) {
     }
     return serialize.binarySet(value);
   case 'map':
-    return serialize.map(value);
+    return serialize.map(value, subSchema);
   case 'list':
-    return serialize.list(value);
+    return serialize.list(value, subSchema);
   default:
     throw new Error('Unsupported schema type - ' + type);
   }

--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -28,7 +28,15 @@ var serialize = internals.serialize = {
   },
 
   boolean : function (value) {
-    if(_.isBoolean(value)) {
+    if(_.isString(value)) {
+      if(value=='true') {
+        return {BOOL: true};
+      } else if (value=='false') {
+        return {BOOL: false};
+      } else {
+        return {BOOL: false};
+      }
+    } else if(_.isBoolean(value)) {
       return {BOOL: value};
     } else {
       return {BOOL: !!value};

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -124,6 +124,25 @@ describe('schema', function () {
     });
   });
 
+  describe('#Map', function () {
+    it('should set as map', function () {
+      schema.Map('scores');
+
+      schema.attrs.should.have.keys(['scores']);
+      schema.attrs.scores.type._type.should.equal('map');
+    });
+  });
+
+
+  describe('#List', function () {
+    it('should set as list', function () {
+      schema.List('scores');
+
+      schema.attrs.should.have.keys(['scores']);
+      schema.attrs.scores.type._type.should.equal('list');
+    });
+  });
+
 
   describe('#validate', function () {
 
@@ -168,14 +187,18 @@ describe('schema', function () {
       schema.Number('age', {default: 3});
       schema.Number('posts', {default: 0});
       schema.Boolean('terms', {default: false});
+      schema.Map('skills', {default: {}});
+      schema.List('jobs', {default: []});
 
-      schema.defaults().should.have.keys(['name', 'age', 'posts', 'terms']);
+      schema.defaults().should.have.keys(['name', 'age', 'posts', 'terms', 'skills', 'jobs']);
     });
 
     it('should return empty object when no defaults exist', function () {
       schema.String('email', {hashKey: true});
       schema.String('name');
       schema.Number('age');
+      schema.Map('skills');
+      schema.List('jobs');
 
       schema.defaults().should.be.empty;
     });
@@ -186,12 +209,16 @@ describe('schema', function () {
       schema.String('email', {hashKey: true});
       schema.String('name', {default: 'Foo Bar'});
       schema.Number('age', {default: 3});
+      schema.Map('skills', {default: {name:'js'}});
+      schema.List('jobs', {default: [{name:'engineer'}]});
 
       var d = schema.applyDefaults({email: 'foo@bar.com'});
 
       d.email.should.equal('foo@bar.com');
       d.name.should.equal('Foo Bar');
       d.age.should.equal(3);
+      d.skills.should.eql({name:'js'});
+      d.jobs.should.eql([{name:'engineer'}]);
     });
 
     it('should return result of default functions', function () {

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -477,6 +477,25 @@ describe('Serializer', function () {
       expect(item).to.not.include.keys('title');
     });
 
+    it('should parse map attribute', function () {
+      schema.Map('skills');
+
+      var itemResp = {skills: {M: { programming:{M: { nodejs:{N:"10"}, ruby:{N:"10"} } } }}};
+
+      var item = serializer.deserializeItem(schema, itemResp);
+
+      item.skills.should.eql({programming: {nodejs: 10, ruby: 10}});
+    });
+
+    it('should parse list attribute', function () {
+      schema.List('tags');
+
+      var itemResp = {tags: { L: [{S: 'john'}, {N: "0"}] }};
+
+      var item = serializer.deserializeItem(schema, itemResp);
+
+      item.tags.should.eql(['john', 0]);
+    });
 
   });
 
@@ -520,7 +539,7 @@ describe('Serializer', function () {
       item.should.eql({ skills: {Action: 'PUT', Value: {M: { programming:{M: { nodejs:{N:"10"}, ruby:{N:"10"} }} }} }});
     });
 
-    it('should serialize ist attribute', function () {
+    it('should serialize list attribute', function () {
       schema.List('tags');
 
       var item = serializer.serializeItemForUpdate(schema, 'PUT', {tags: ['john', 0]});

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -478,7 +478,9 @@ describe('Serializer', function () {
     });
 
     it('should parse map attribute', function () {
-      schema.Map('skills');
+      schema.Map('skills', function(schema){
+        schema.Map('programming');
+      });
 
       var itemResp = {skills: {M: { programming:{M: { nodejs:{N:"10"}, ruby:{N:"10"} } } }}};
 
@@ -488,13 +490,16 @@ describe('Serializer', function () {
     });
 
     it('should parse list attribute', function () {
-      schema.List('tags');
+      schema.List('tags', function(schema){
+        schema.String('name');
+        schema.Number('point');
+      });
 
-      var itemResp = {tags: { L: [{S: 'john'}, {N: "0"}] }};
+      var itemResp = {tags: { L: [{M: {name: {S: 'john'}, point: {N: "10"}}}, {M: {name: {S: 'lennon'}, point: {N: "20"}}}] }};
 
       var item = serializer.deserializeItem(schema, itemResp);
 
-      item.tags.should.eql(['john', 0]);
+      item.tags.should.eql([{name: 'john', point: 10}, {name: 'lennon', point: 20}]);
     });
 
   });
@@ -532,7 +537,9 @@ describe('Serializer', function () {
     });
 
     it('should serialize map attribute', function () {
-      schema.Map('skills');
+      schema.Map('skills', function(schema){
+        schema.Map('programming');
+      });
 
       var item = serializer.serializeItemForUpdate(schema, 'PUT', {skills: {programming: {nodejs: 10, ruby: 10}}});
 
@@ -540,11 +547,14 @@ describe('Serializer', function () {
     });
 
     it('should serialize list attribute', function () {
-      schema.List('tags');
+      schema.List('tags', function(schema){
+        schema.String('name');
+        schema.Number('point');
+      });
 
-      var item = serializer.serializeItemForUpdate(schema, 'PUT', {tags: ['john', 0]});
+      var item = serializer.serializeItemForUpdate(schema, 'PUT', {tags: [{name: 'john', point: 10}, {name: 'lennon', point: 20}]});
 
-      item.should.eql({ tags: {Action: 'PUT', Value: { L: [{S: 'john'}, {N: "0"}] } }});
+      item.should.eql({ tags: {Action: 'PUT', Value: { L: [{M: {name: {S: 'john'}, point: {N: "10"}}}, {M: {name: {S: 'lennon'}, point: {N: "20"}}}] }}});
     });
 
     it('should serialize null value to a DELETE action', function () {

--- a/test/serializer-test.js
+++ b/test/serializer-test.js
@@ -113,7 +113,7 @@ describe('Serializer', function () {
       var data = { email : 'test@example.com', adult: false };
       var keys = serializer.buildKey(data, null, schema);
 
-      keys.should.eql({email: {S: 'test@example.com'}, adult: {N : '0'}});
+      keys.should.eql({email: {S: 'test@example.com'}, adult: {BOOL : false}});
     });
 
   });
@@ -205,13 +205,13 @@ describe('Serializer', function () {
     it('should serialize boolean attribute', function () {
       schema.Boolean('agree');
 
-      serializer.serializeItem(schema, {agree: true}).should.eql({agree: {N: '1'}});
-      serializer.serializeItem(schema, {agree: 'true'}).should.eql({agree: {N: '1'}});
+      serializer.serializeItem(schema, {agree: true}).should.eql({agree: {BOOL: true}});
+      serializer.serializeItem(schema, {agree: 'true'}).should.eql({agree: {BOOL: true}});
 
-      serializer.serializeItem(schema, {agree: false}).should.eql({agree: {N: '0'}});
-      serializer.serializeItem(schema, {agree: 'false'}).should.eql({agree: {N: '0'}});
-      //serializer.serializeItem(schema, {agree: null}).should.eql({agree: {N: '0'}});
-      serializer.serializeItem(schema, {agree: 0}).should.eql({agree: {N: '0'}});
+      serializer.serializeItem(schema, {agree: false}).should.eql({agree: {BOOL: false}});
+      serializer.serializeItem(schema, {agree: 'false'}).should.eql({agree: {BOOL: false}});
+      //serializer.serializeItem(schema, {agree: null}).should.eql({agree: {BOOL: false}});
+      serializer.serializeItem(schema, {agree: 0}).should.eql({agree: {BOOL: false}});
     });
 
     it('should serialize date attribute', function () {
@@ -512,6 +512,22 @@ describe('Serializer', function () {
       });
     });
 
+    it('should serialize map attribute', function () {
+      schema.Map('skills');
+
+      var item = serializer.serializeItemForUpdate(schema, 'PUT', {skills: {programming: {nodejs: 10, ruby: 10}}});
+
+      item.should.eql({ skills: {Action: 'PUT', Value: {M: { programming:{M: { nodejs:{N:"10"}, ruby:{N:"10"} }} }} }});
+    });
+
+    it('should serialize ist attribute', function () {
+      schema.List('tags');
+
+      var item = serializer.serializeItemForUpdate(schema, 'PUT', {tags: ['john', 0]});
+
+      item.should.eql({ tags: {Action: 'PUT', Value: { L: [{S: 'john'}, {N: "0"}] } }});
+    });
+
     it('should serialize null value to a DELETE action', function () {
       schema.String('name');
       schema.Number('age');
@@ -570,6 +586,7 @@ describe('Serializer', function () {
         ages : {Action: 'DELETE', Value: {NS: ['2', '3']}}
       });
     });
+
 
   });
 });


### PR DESCRIPTION
DynamoDB now supports to store entire JSON-formatted documents as single items.
http://aws.amazon.com/jp/blogs/aws/dynamodb-update-json-and-more/
In this update, following new attribute types have been added:
 * Map
 * List
 * Boolean
 * Null

This pull request adds a feature to support Map, List and Boolean type of attribute.
In Map and List attribute, it currently does not validate its content format.