### PR TITLE
Fix for boolean attributes

### DIFF
--- a/lib/serializer.js
+++ b/lib/serializer.js
@@ -38,9 +38,9 @@ var serialize = internals.serialize = {
 
   boolean : function (value) {
     if (value && value !== 'false') {
-      return true;
+      return 'true';
     } else {
-      return false;
+      return 'false';
     }
   },
 


### PR DESCRIPTION
Got this exception in aws-sdk when trying to put an item that contains booleans:

```
ValidationException: Supplied AttributeValue is empty, must contain exactly one of the supported datatypes
```