### PR TITLE
Schema Validation on Update

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -164,9 +164,9 @@ Table.prototype.update = function (item, options, callback) {
 
     var validation = self.schema.validate(data);
 
-	if (validation.error) {
-		return callback(data.error);
-	}
+    if (validation.error) {
+      return callback(data.error);
+    }
 
     var hashKey = data[self.schema.hashKey];
     var rangeKey = data[self.schema.rangeKey] || null;

--- a/lib/table.js
+++ b/lib/table.js
@@ -162,6 +162,12 @@ Table.prototype.update = function (item, options, callback) {
       return callback(err);
     }
 
+    var validation = self.schema.validate(data);
+
+	if (validation.error) {
+		return callback(data.error);
+	}
+
     var hashKey = data[self.schema.hashKey];
     var rangeKey = data[self.schema.rangeKey] || null;
 


### PR DESCRIPTION
It became a pretty big issue to not do schema validation on update, since dependencies as dynamodb-doc would throw an error if you would update a StringSet with undefined.

My PR would enforce the schema on updates as well.

```bash
C:\app\node_modules\vogels\node_modules\dynamodb-doc\lib\datatypes.js:208
                    throw new Error("Inconsistent in this " + type + " Set");
                          ^
Error: Inconsistent in this S Set
    at Set.add (C:\app\node_modules\vogels\node_modules\dynamodb-doc\lib\datatypes.js:208:27)
    at new Set (C:\app\node_modules\vogels\node_modules\dynamodb-doc\lib\datatypes.js:254:26)
    at DynamoDBDatatype.createSet (C:\app\node_modules\vogels\node_modules\dynamodb-doc\lib\datatypes.js:259:16)
    at DynamoDB.service.__proto__.Set (C:\app\node_modules\vogels\node_modules\dynamodb-doc\lib\dynamodb-doc.js:44:18)
    at Object.internals.createSet (C:\app\node_modules\vogels\lib\serializer.js:17:32)
    at Object.internals.serialize.stringSet (C:\app\node_modules\vogels\lib\serializer.js:48:22)
    at Object.internals.serializeAttribute.serializer.serializeAttribute (C:\app\node_modules\vogels\lib\serializer.js:96:22)
    at C:\app\node_modules\vogels\lib\expressions.js:70:44
    at C:\app\node_modules\vogels\node_modules\lodash\dist\lodash.js:3740:15
    at forOwn (C:\app\node_modules\vogels\node_modules\lodash\dist\lodash.js:2105:15)
```