### PR TITLE
Change dynamodb-doc to be installed from npm rather than a github checkout

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "license": "MIT",
   "dependencies": {
     "aws-sdk": "2.1.x",
-    "dynamodb-doc": "awslabs/dynamodb-document-js-sdk",
+    "dynamodb-doc": "1.0.0",
     "lodash": "3.1.x",
     "joi": "5.x.x",
     "node-uuid": "1.4.x",


### PR DESCRIPTION
We are using this project, but the dynamodb-doc was preventing us from deploying to our staging and production environment due to our security policies.

To work around this we have forked our own version of this module using the npm dependency which works for us.

I'm hoping that the same change we have made internally will also be OK publicly. This would also mean we won't need our fork.