### PR TITLE
Small update in the tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ You can also directly pass in your access key id and secret
 
 ```js
 var vogels = require('vogels');
-vogels.AWS.config.update({accessKeyId: 'AKID', secretAccessKey: 'SECRET'});
+vogels.AWS.config.update({accessKeyId: 'AKID', secretAccessKey: 'SECRET', region: "your-region-code"});
 ```
+
 
 ### Define a Model
 Models are defined through the toplevel define method.

--- a/README.md
+++ b/README.md
@@ -23,12 +23,25 @@ var vogels = require('vogels');
 vogels.AWS.config.loadFromPath('credentials.json');
 ```
 
-You can also directly pass in your access key id and secret
+You can also pass in your access key id, secret and region code directly as parameter object to the following function:
 
 ```js
 var vogels = require('vogels');
 vogels.AWS.config.update({accessKeyId: 'AKID', secretAccessKey: 'SECRET', region: "your-region-code"});
 ```
+Currently the following region codes are available in Amazon:
+
+|      Code      |           Name           |
+| -------------- | ------------------------ |
+| ap-northeast-1 | Asia Pacific (Tokyo)     |
+| ap-southeast-1 | Asia Pacific (Singapore) |
+| ap-southeast-2 | Asia Pacific (Sydney)    |
+| eu-central-1   | EU (Frankfurt)           |
+| eu-west-1      | EU (Ireland)             |
+| sa-east-1      | South America (Sao Paulo)|
+| us-east-1      | US East (N. Virginia)    |
+| us-west-1      | US West (N. California)  |
+| us-west-2      | US West (Oregon)         |
 
 
 ### Define a Model


### PR DESCRIPTION
The region code is mandatory and you'll get exception if you don't specify it in the AWS config object.
The available region codes are as specified by amazon:

```
ap-northeast-1
ap-southeast-1
ap-southeast-2
eu-central-1
eu-west-1
sa-east-1
us-east-1
us-west-1
us-west-2
```