### PR TITLE
Add create index to updateTables

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,7 +9,8 @@ var _            = require('lodash'),
     serializer   = require('./serializer'),
     batch        = require('./batch'),
     Item         = require('./item'),
-    createTables = require('./createTables');
+    createTables = require('./createTables'),
+    updateTables = require('./updateTables');
 
 var vogels = module.exports;
 
@@ -139,6 +140,18 @@ vogels.model = function(name, model) {
   }
 
   return vogels.models[name] || null;
+};
+
+vogels.updateTables = function (options, callback) {
+  if (typeof options === 'function' && !callback) {
+    callback = options;
+    options = {};
+  }
+
+  callback = callback || _.noop;
+  options = options || {};
+
+  return updateTables(vogels.models, options, callback);
 };
 
 vogels.createTables = function (options, callback) {

--- a/lib/table.js
+++ b/lib/table.js
@@ -430,6 +430,38 @@ internals.globalIndex = function (indexName, params) {
   };
 };
 
+internals.globalIndexCreate = function (indexName, params) {
+  var projection = params.projection || { ProjectionType : 'ALL' };
+
+  return {
+    Create:
+    {
+      IndexName : indexName,
+      KeySchema : internals.keySchema(params.hashKey, params.rangeKey),
+      Projection : projection,
+      ProvisionedThroughput: {
+        ReadCapacityUnits: params.readCapacity || 1,
+        WriteCapacityUnits: params.writeCapacity || 1
+      }
+    }
+  };
+};
+
+internals.globalIndexUpdate = function (indexName, params) {
+  var projection = params.projection || { ProjectionType : 'ALL' };
+
+  return {
+    Update:
+    {
+      IndexName : indexName,
+      ProvisionedThroughput: {
+        ReadCapacityUnits: params.readCapacity || 1,
+        WriteCapacityUnits: params.writeCapacity || 1
+      }
+    }
+  };
+};
+
 Table.prototype.createTable = function (options, callback) {
   var self = this;
 
@@ -509,16 +541,56 @@ Table.prototype.deleteTable = function (callback) {
   this.docClient.deleteTable(params, callback);
 };
 
-Table.prototype.updateTable = function (throughput, callback) {
+Table.prototype.updateTable = function (throughput, existingIndexes, existingThroughput, callback) {
+  var self = this;
+
   callback = callback || _.noop;
+
+  existingIndexes = existingIndexes || [];
+  existingThroughput = existingThroughput || {};
+  throughput.readCapacity = throughput.readCapacity || 1;
+  throughput.writeCapacity = throughput.writeCapacity || 1;
+
+  var globalSecondaryIndexUpdates = [];
+
+  var attributeDefinitions = [];
+
+  _.forEach(self.schema.globalIndexes, function (params, indexName) {
+
+    if(!_.find(attributeDefinitions, { 'AttributeName': params.hashKey })) {
+      attributeDefinitions.push(internals.attributeDefinition(self.schema, params.hashKey));
+    }
+
+    if(params.rangeKey && !_.find(attributeDefinitions, { 'AttributeName': params.rangeKey })) {
+      attributeDefinitions.push(internals.attributeDefinition(self.schema, params.rangeKey));
+    }
+
+    if (existingIndexes.indexOf(indexName) === -1) {
+      globalSecondaryIndexUpdates.push(internals.globalIndexCreate(indexName, params));
+    //} else {
+    //  globalSecondaryIndexUpdates.push(internals.globalIndexUpdate(indexName, params));
+    }
+  });
 
   var params = {
     TableName : this.tableName(),
-    ProvisionedThroughput : {
-      ReadCapacityUnits : throughput.readCapacity,
-      WriteCapacityUnits : throughput.writeCapacity
-    }
+    AttributeDefinitions : attributeDefinitions
   };
 
-  this.docClient.updateTable(params, callback);
+  if(globalSecondaryIndexUpdates.length >= 1) {
+    params.GlobalSecondaryIndexUpdates = globalSecondaryIndexUpdates;
+  }
+  if (throughput.readCapacity !== existingThroughput.ReadCapacityUnits) {
+    params.ProvisionedThroughput = params.ProvisionedThroughput || {};
+    params.ProvisionedThroughput.ReadCapacityUnits = throughput.readCapacity;
+  }
+  if (throughput.writeCapacity !== existingThroughput.WriteCapacityUnits) {
+    params.ProvisionedThroughput = params.ProvisionedThroughput || {};
+    params.ProvisionedThroughput.WriteCapacityUnits = throughput.writeCapacity;
+  }
+  if(params.GlobalSecondaryIndexUpdates || params.ProvisionedThroughput) {
+    this.docClient.updateTable(params, callback);
+  } else {
+    callback();
+  }
 };

--- a/lib/updateTables.js
+++ b/lib/updateTables.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var async = require('async'),
+    _     = require('lodash');
+
+var internals = {};
+
+internals.updateTable = function (model, options, callback) {
+  options = options || {};
+
+  var tableName = model.tableName();
+
+  model.describeTable(function (err, data) {
+    if(!_.isNull(data)) {
+      var existingIndexes = _.pluck(data.Table.GlobalSecondaryIndexes, 'IndexName');
+      var existingThroughput = data.Table.ProvisionedThroughput;
+      console.log('updating table', tableName);
+      return model.updateTable(options, existingIndexes, existingThroughput, function (error) {
+
+        if(error) {
+          console.error('failed to updated table ' + tableName, error);
+          return callback(error);
+        }
+
+        console.log('waiting for table ' + tableName + ' to become ACTIVE');
+        internals.waitTillActive(model, callback);
+      });
+    } else {
+      console.log('table does not exist', tableName);
+      return callback();
+    }
+  });
+};
+
+internals.waitTillActive = function (model, callback) {
+  var status = 'PENDING';
+
+  async.doWhilst(
+    function (callback) {
+      model.describeTable(function (err, data) {
+        if(err) {
+          return callback(err);
+        }
+        var indexStatuses = _.pluck(data.Table.GlobalSecondaryIndexes, 'IndexStatus');
+        if (indexStatuses.every(function(element) { return element === 'ACTIVE'; })) {
+          status = 'ACTIVE';
+        }
+        setTimeout(callback, 1000);
+      });
+    },
+    function () { return status !== 'ACTIVE'; },
+    function (err) {
+      return callback(err);
+    });
+};
+
+module.exports = function (models, config, callback) {
+  async.eachSeries(_.keys(models), function (key, callback) {
+    return internals.updateTable(models[key], config[key], callback);
+  }, callback);
+};


### PR DESCRIPTION
This is a naive attempt to add the ability to create indexes that do not already exist when running updateTable and a helper to update all tables similar to createTables.

This pull request is only for feedback and direction.  I would like to be able to do this without having to change the signature of Table.prototype.updateTable.  I would like to check if there are new indexes in the schema definition earlier but in internals.updateTable could not figure out how to get the table schema on the model object from the closure where the model is defined.

Tests have not been updated yet as I don't think this solution is ideal.

Thanks,
Justin