### PR TITLE
omit empty string attributes when creating new records. Closes #42

### DIFF
--- a/lib/expressions.js
+++ b/lib/expressions.js
@@ -54,7 +54,7 @@ exports.serializeUpdateExpression = function (schema, item) {
     var valueKey = ':' + key;
     var nameKey = '#' + key;
 
-    if(_.isNull(value)) {
+    if(_.isNull(value) || (_.isString(value) && _.isEmpty(value)) ) {
       result.expressions.REMOVE.push(nameKey);
       result.attributeNames[nameKey] = key;
     } else if (_.isPlainObject(value) && value.$add) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,7 +9,10 @@ var utils = module.exports;
 
 utils.omitNulls = function (data) {
   return _.omit(data, function(value) {
-    return _.isNull(value) || _.isUndefined(value) || (_.isArray(value) && _.isEmpty(value));
+    return _.isNull(value) ||
+      _.isUndefined(value) ||
+      (_.isArray(value) && _.isEmpty(value)) ||
+      (_.isString(value) && _.isEmpty(value));
   });
 };
 

--- a/test/expressions-test.js
+++ b/test/expressions-test.js
@@ -258,6 +258,29 @@ describe('expressions', function () {
 
     });
 
+    it('should return single REMOVE action when value is set to empty string', function () {
+      var updates = {
+        id : 'foobar',
+        email : '',
+      };
+
+      var result = expressions.serializeUpdateExpression(schema, updates);
+
+      expect(result.expressions).to.eql({
+        SET    : [],
+        ADD    : [],
+        REMOVE : ['#email'],
+        DELETE : [],
+      });
+
+      expect(result.values).to.eql({});
+
+      expect(result.attributeNames).to.eql({
+        '#email' : 'email'
+      });
+
+    });
+
     it('should return empty actions when passed empty object', function () {
       var result = expressions.serializeUpdateExpression(schema, {});
 

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -81,7 +81,7 @@ describe('Vogels Integration Tests', function() {
       schema : {
         id            : Joi.string().required().default(uuid.v4),
         email         : Joi.string().required(),
-        name          : Joi.string(),
+        name          : Joi.string().allow(''),
         age           : Joi.number().min(10),
         roles         : vogels.types.stringSet().default(['user']),
         acceptedTerms : Joi.boolean().default(false),
@@ -145,6 +145,9 @@ describe('Vogels Integration Tests', function() {
         var items = [{fiz : 3, buz : 5, fizbuz: 35}];
         User.create({id : '123456789', email : 'some@user.com', age: 30, settings : {nickname : 'thedude'}, things : items}, callback);
       },
+      function (callback) {
+        User.create({id : '9999', email : '9999@test.com', age: 99, name: 'Nancy Nine'}, callback);
+      },
       internals.loadSeedData
     ], done);
   });
@@ -158,6 +161,24 @@ describe('Vogels Integration Tests', function() {
         acceptedTerms : true,
         settings : {
           nickname : 'fooos',
+          version : 2
+        }
+      }, function (err, acc) {
+        expect(err).to.not.exist;
+        expect(acc).to.exist;
+        expect(acc.get()).to.have.keys(['id', 'email', 'age', 'roles', 'acceptedTerms', 'settings']);
+        return done();
+      });
+    });
+
+    it('should create item with empty string', function(done) {
+      User.create({
+        email : 'foo2@bar.com',
+        name : '',
+        age : 22,
+        roles : ['user'],
+        settings : {
+          nickname : 'foo2',
           version : 2
         }
       }, function (err, acc) {
@@ -251,6 +272,16 @@ describe('Vogels Integration Tests', function() {
         expect(acc.get()).to.have.keys(['id', 'email', 'age', 'roles', 'acceptedTerms', 'settings', 'things']);
         expect(acc.get('roles').sort()).to.eql(['tester', 'user']);
 
+        return done();
+      });
+    });
+
+    it('should remove name attribute from user record when set to empty string', function(done) {
+      User.update({ id : '9999', name : ''}, function (err, acc) {
+        expect(err).to.not.exist;
+        expect(acc).to.exist;
+
+        expect(acc.get()).to.have.keys(['id', 'email', 'age', 'roles', 'acceptedTerms']);
         return done();
       });
     });

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -334,6 +334,41 @@ describe('table', function () {
       });
     });
 
+    it('should omit empty values', function (done) {
+      var config = {
+        hashKey: 'email',
+        schema : {
+          email : Joi.string(),
+          name  : Joi.string().allow(''),
+          age   : Joi.number()
+        }
+      };
+
+      var s = new Schema(config);
+
+      table = new Table('accounts', s, realSerializer, docClient, logger);
+
+      var request = {
+        TableName: 'accounts',
+        Item : {
+          email : 'test@test.com',
+          age   : 2
+        }
+      };
+
+      docClient.put.withArgs(request).yields(null, {});
+
+      table.create({email: 'test@test.com', name: '', age: 2}, function (err, account) {
+        expect(err).to.not.exist;
+        account.should.be.instanceof(Item);
+
+        account.get('email').should.equal('test@test.com');
+        account.get('age').should.equal(2);
+
+        done();
+      });
+    });
+
     it('should create item with createdAt timestamp', function (done) {
       var config = {
         hashKey: 'email',


### PR DESCRIPTION
remove attribute when updating a record and attribute is set to empty string