### PR TITLE
Custom instance methods for models

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,11 @@ var Account = vogels.define('Account', {
     }
   },
   
-  // *optional* add some instance methods
+  // custom instance methods
   methods : {
-    fullname: function(){ return this.get('fistname') + ' ' + this.get('lastname') ; }
+    fullname: function(){ 
+        return this.get('fistname') + ' ' + this.get('lastname') ; 
+    }
   }
 });
 ```

--- a/README.md
+++ b/README.md
@@ -63,14 +63,20 @@ var Account = vogels.define('Account', {
   timestamps : true,
 
   schema : {
-    email   : Joi.string().email(),
-    name    : Joi.string(),
-    age     : Joi.number(),
-    roles   : vogels.types.stringSet(),
-    settings : {
+    email       : Joi.string().email(),
+    firstname   : Joi.string(),
+    lastname    : Joi.string(),
+    age         : Joi.number(),
+    roles       : vogels.types.stringSet(),
+    settings    : {
       nickname      : Joi.string(),
       acceptedTerms : Joi.boolean().default(false)
     }
+  },
+  
+  // *optional* add some instance methods
+  methods : {
+    fullname: function(){ return this.get('fistname') + ' ' + this.get('lastname') ; }
   }
 });
 ```
@@ -207,6 +213,30 @@ Account.config({dynamodb: dynamodb});
 // all defined models will now use this driver
 vogels.dynamoDriver(dynamodb);
 ```
+
+Want to define some custom instance methods for your models? Just create a methods object in your schema definition with your custom methods:
+
+**WARNING: your custom methods will override vogel's methods that have the same name!**
+
+```js
+var Event = vogels.define('Event', {
+  hashKey : 'lastname',
+  schema : {
+    firstname : Joi.string(),
+    lastname : Joi.string()
+  },
+  methods: {
+    fullname: function(){
+        return this.get('firstname') + ' ' + this.get('lastname');
+    }
+  }
+});
+
+var evt = new Event({firstname: 'John',lastname: 'Appleseed'});
+console.log(evt.fullname()); //John Appleseed
+
+```
+
 
 ### Saving Models to DynamoDB
 With your models defined, we can start saving them to DynamoDB.

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ Account.config({dynamodb: dynamodb});
 vogels.dynamoDriver(dynamodb);
 ```
 
-Want to define some custom instance methods for your models? Just create a methods object in your schema definition with your custom methods:
+Whant to define some custom instance methods for your models? Just create a methods object in your schema definition with your custom methods:
 
 **WARNING: your custom methods will override vogel's methods that have the same name!**
 
@@ -234,7 +234,6 @@ var Event = vogels.define('Event', {
 
 var evt = new Event({firstname: 'John',lastname: 'Appleseed'});
 console.log(evt.fullname()); //John Appleseed
-
 ```
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -76,6 +76,10 @@ internals.compileModel = function (name, schema) {
 
   var Model = function (attrs) {
     Item.call(this, attrs, table);
+    // add custom instance methods to item
+    for(var m in schema.methods){
+      this[m] = _.bind(schema.methods[m], this);
+    }
   };
 
   util.inherits(Model, Item);

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -22,6 +22,7 @@ internals.configSchema = Joi.object().keys({
   tableName : Joi.alternatives().try(Joi.string(), Joi.func()),
   indexes   : Joi.array().includes(internals.secondaryIndexSchema),
   schema    : Joi.object(),
+  methods   : Joi.object().pattern(/.+/, Joi.func()),
   timestamps : Joi.boolean().default(false),
   createdAt  : Joi.alternatives().try(Joi.string(), Joi.boolean()),
   updatedAt  : Joi.alternatives().try(Joi.string(), Joi.boolean())
@@ -95,6 +96,7 @@ var Schema = module.exports = function (config) {
     self.timestamps = data.timestamps;
     self.createdAt  = data.createdAt;
     self.updatedAt  = data.updatedAt;
+    self.methods    = data.methods;
 
     if(data.indexes) {
       self.globalIndexes    = _.chain(data.indexes).filter({ type: 'global' }).indexBy('name').value();

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -62,6 +62,20 @@ describe('vogels', function () {
       acc.table.should.be.instanceof(Table);
     });
 
+    it('should return new account item with a custom method', function () {
+      var Account = vogels.define('Account', {
+        hashKey : 'id',
+        methods: {
+          customMethod: function(){
+            return this.get('name')
+          }
+        }
+      });
+
+      var acc = new Account({name: 'Test Acc'});
+      acc.customMethod().should.be.equal('Test Acc');
+    });
+
   });
 
   describe('#models', function () {

--- a/test/schema-test.js
+++ b/test/schema-test.js
@@ -250,6 +250,19 @@ describe('schema', function () {
       }).to.throw(/hashKey is required/);
     });
 
+    it('should throw when method is not a function', function () {
+      var config = {
+        hashKey : 'foo',
+        methods: {
+          bar: "value"
+        }
+      };
+
+      expect(function () {
+        new Schema(config);
+      }).to.throw(/bar must be a Function/);
+    });
+
     it('should parse schema data types', function () {
       var config = {
         hashKey : 'foo',


### PR DESCRIPTION
Added support for custom instance methods for models, like this:

```js
var Event = vogels.define('Event', {
  hashKey : 'lastname',
  schema : {
    firstname : Joi.string(),
    lastname : Joi.string()
  },
  methods: {
    fullname: function(){
        return this.get('firstname') + ' ' + this.get('lastname');
    }
  }
});

var evt = new Event({firstname: 'John',lastname: 'Appleseed'});
console.log(evt.fullname()); //John Appleseed
```

Updated README.md and added tests.

The way it was implemented allows those custom methods to override vogel's methods with the same name. Added a warning in the README about that.