### PR TITLE
ReturnValues of destroy example in README is wrong

### DIFF
--- a/README.md
+++ b/README.md
@@ -429,7 +429,7 @@ BlogPost.destroy({email: 'foo@example.com', title: 'Another Post'}, function (er
 `Model.destroy` accepts options to pass to DynamoDB when making the deleteItem request
 
 ```js
-Account.destroy('foo@example.com', {ReturnValues: true}, function (err, acc) {
+Account.destroy('foo@example.com', {ReturnValues: 'ALL_OLD'}, function (err, acc) {
   console.log('account deleted');
   console.log('deleted account name', acc.get('name'));
 });


### PR DESCRIPTION
If ReturnValues is true, InvalidParameterType will be thrown.

InvalidParameterType: Expected params.ReturnValues to be a string
