### PR TITLE
Add table name to validation errors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp
 covreporter/
 coverage/
 .tern-port
+.idea

--- a/lib/table.js
+++ b/lib/table.js
@@ -160,6 +160,7 @@ internals.createItem = function (table, item, options, callback) {
     var result = self.schema.validate(data);
 
     if(result.error) {
+      result.error.message = result.error.message + ' on ' + self.tableName();
       return callback(result.error);
     }
 
@@ -674,7 +675,7 @@ internals.syncIndexes = function (table, callback) {
 
 internals.findMissingGlobalIndexes = function (table, data) {
   if(_.isNull(data) || _.isUndefined(data)) {
-    // table does not exist 
+    // table does not exist
     return table.schema.globalIndexes;
   } else {
     var indexData = _.get(data, 'Table.GlobalSecondaryIndexes');


### PR DESCRIPTION
When validation (joi) errors occur there is no context to help determine what table the error occurred on.  This small pull request fixes this.  The more robust approach would be to extend Error and add table as a property and then modify the toString function, but that may be more than is needed.
