### PR TITLE
Handle thrown errors during updateExpressions

### DIFF
--- a/lib/table.js
+++ b/lib/table.js
@@ -266,7 +266,12 @@ Table.prototype.update = function (item, options, callback) {
       ReturnValues : 'ALL_NEW'
     };
 
-    var exp = internals.updateExpressions(self.schema, data, options);
+    var exp = null;
+    try {
+      exp = internals.updateExpressions(self.schema, data, options);
+    } catch (e) {
+      return callback(e);
+    }
 
     if(exp.UpdateExpression) {
       params.UpdateExpression = exp.UpdateExpression;

--- a/test/table-test.js
+++ b/test/table-test.js
@@ -872,6 +872,27 @@ describe('table', function () {
       });
     });
 
+    it('should handle errors regarding invalid expressions', function (done) {
+      var config = {
+        hashKey: 'name',
+        schema : {
+          name     : Joi.string(),
+          birthday : Joi.date().iso()
+        }
+      };
+
+      var s = new Schema(config);
+
+      table = new Table('accounts', s, realSerializer, docClient, logger);
+
+      var item = {name : 'Dr. Who', birthday: undefined};
+
+      table.update(item, function (err, account) {
+        expect(err).to.exist;
+        expect(account).to.not.exist;
+        done();
+      });
+    });
   });
 
   describe('#query', function () {


### PR DESCRIPTION
Proposal to resolve #151 

While performing an update with an invalid date value, vogels throws an error (example is listed in the issue). This causes issues when vogels is used in a callback-style workflow.

I couldn't find a contributing guide of sorts, so I tried to keep the style similar to other code segments. I am open to suggestions and feedback 😸 
