### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Joi      = require('joi'),
-    nodeUUID = require('node-uuid'),
+    nodeUUID = require('uuid'),
     _        = require('lodash');
 
 var internals =  {};

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "bunyan": "1.5.x",
     "joi": "5.x.x",
     "lodash": "4.x.x",
-    "node-uuid": "1.4.x"
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "chai": "1.x.x",

--- a/test/integration/integration-test.js
+++ b/test/integration/integration-test.js
@@ -6,7 +6,7 @@ var vogels = require('../../index'),
     async  = require('async'),
     _      = require('lodash'),
     helper = require('../test-helper'),
-    uuid   = require('node-uuid'),
+    uuid   = require('uuid'),
     Joi    = require('joi');
 
 chai.should();


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.