### PR TITLE
Fix BatchGetItem paginated request data format.

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -48,7 +48,7 @@ internals.paginatedRequest = function (request, table, callback) {
         return callback(err);
       }
 
-      request = resp.UnprocessedKeys;
+      request = { RequestItems: resp.UnprocessedKeys };
       responses.push(resp);
 
       return callback();
@@ -56,7 +56,7 @@ internals.paginatedRequest = function (request, table, callback) {
   };
 
   var testFunc = function () {
-    return request !== null && !_.isEmpty(request);
+    return !_.isEmpty(_.get(request, 'RequestItems'));
   };
 
   var resulsFunc = function (err) {


### PR DESCRIPTION
This fixes the format of paginated BatchGetItem request using `Table.getItems`.

Without this change, the first request would succeed, but subsequent paginated requests would fail with `MissingRequiredParameter: Missing required key 'RequestItems' in params`.  This is because the requested keys were sent as the request, rather than being placed on `request.RequestItems`.

Note that a large number of items must be requested in order for BatchGetItem requests to be paginated.  Even with 5000 items requested DynamoDB would sometimes return them all in one response.